### PR TITLE
UI improvements: remove color bars and limit function signatures

### DIFF
--- a/app/src/main/java/top/wsdx233/r2droid/feature/bininfo/ui/BinInfoLists.kt
+++ b/app/src/main/java/top/wsdx233/r2droid/feature/bininfo/ui/BinInfoLists.kt
@@ -99,11 +99,8 @@ private fun TintedItemSurface(
         tonalElevation = 0.dp,
         shape = shape
     ) {
-        Row(modifier = Modifier.height(IntrinsicSize.Min).fillMaxWidth()) {
-            AccentBar(accentColor)
-            Box(modifier = Modifier.weight(1f)) {
-                content()
-            }
+        Box(modifier = Modifier.fillMaxWidth()) {
+            content()
         }
     }
 }
@@ -461,9 +458,15 @@ fun FunctionItem(func: FunctionInfo, actions: ListItemActions) {
                     Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
                         InfoTag("sz:${func.size}")
                         InfoTag("bbs:${func.nbbs}")
-                        if (func.signature.isNotEmpty()) {
-                            InfoTag(func.signature, MaterialTheme.colorScheme.onSurfaceVariant)
-                        }
+                    }
+                    if (func.signature.isNotEmpty()) {
+                        Text(
+                            text = func.signature,
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
                     }
                 }
                 AddressBadge(func.addr, accent)


### PR DESCRIPTION
## Changes

This PR includes two UI improvements for the binary info list view:

1. **Remove color bars from list view items** - Removed the 8dp colored accent bar that appeared on the left side of each list item. The items now have a cleaner, simpler appearance while maintaining the tinted background.

2. **Limit function signatures to one line** - Function signatures in the function list are now displayed on a separate line and limited to a single line with ellipsis overflow. This prevents long signatures from taking up too much vertical space.

## Modified Files
- `app/src/main/java/top/wsdx233/r2droid/feature/bininfo/ui/BinInfoLists.kt`
  - Modified `TintedItemSurface` composable to remove the `AccentBar` component
  - Modified `FunctionItem` composable to display signatures with `maxLines = 1` and `overflow = TextOverflow.Ellipsis`

## Screenshots
*Before*: List items had colored bars on the left side, function signatures were inline with tags
*After*: Cleaner list items without color bars, function signatures are on a separate line with ellipsis

---
🤖 Generated with Claude Code